### PR TITLE
Fix relation to EABase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ add_definitions(-D_CHAR16T)
 # Export Include Directories
 #-------------------------------------------------------------------------------------------
 target_include_directories(EAAssert PUBLIC include)
+target_include_directories(EAAssert PRIVATE ../EABase/include/Common)
 
 #-------------------------------------------------------------------------------------------
 # Package Dependencies 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,4 @@ add_definitions(-D_CHAR16T)
 target_include_directories(EAAssert PUBLIC include)
 target_include_directories(EAAssert PRIVATE ../EABase/include/Common)
 
-#-------------------------------------------------------------------------------------------
-# Package Dependencies 
-#-------------------------------------------------------------------------------------------
-target_link_libraries(EAAssert EABase)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,7 @@ add_subdirectory(packages/EAStdC)
 add_subdirectory(packages/EATest)
 add_subdirectory(packages/EAThread)
 
-target_link_libraries(EAAssertTest EABase)
+)
 target_link_libraries(EAAssertTest EAMain)
 target_link_libraries(EAAssertTest EASTL)
 target_link_libraries(EAAssertTest EAStdC)


### PR DESCRIPTION
Change from link to include - the libraries won't build otherwise on Ubuntu.
I'm guessing that in the past EABase *was* a binary library to link against, and was changed to header only - but I didn't chase its history.