### PR TITLE
Fix eaassert.h include guard

### DIFF
--- a/include/EAAssert/eaassert.h
+++ b/include/EAAssert/eaassert.h
@@ -2,10 +2,6 @@
 // Copyright (c) Electronic Arts Inc. All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
-#if defined(EA_PRAGMA_ONCE_SUPPORTED)
-	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
-#endif
-
 #ifndef EAASSERT_EAASSERT_H
 #define EAASSERT_EAASSERT_H
 
@@ -41,6 +37,9 @@
 #include "EABase/eabase.h"
 #include <stdarg.h>
 
+#if defined(EA_PRAGMA_ONCE_SUPPORTED)
+	#pragma once // Some compilers (e.g. VC++) benefit significantly from using this. We've measured 3-4% build speed improvements in apps as a result.
+#endif
 
 // The default assert handling mechanism just breaks into the debugger on an assert failure. If you wish to overwrite this 
 // functionality, simply implement the following callback:


### PR DESCRIPTION
`eaassert.h` does not have a strict enough include guard to trigger the multiple inclusion optimization on most compilers.

The `#if defined(EA_PRAGMA_ONCE_SUPPORTED)` check occurs before any include of `eacompilertraits.h` (where `EA_PRAGMA_ONCE_SUPPORTED` is defined) so the preprocessor sees the `#pragma once` only if `eaassert.h` is included **after** another header that includes `eacompilertraits.h`.

The traditional include guard is also not strict enough to trigger the multiple-inclusion optimization as the only tokens that can appear outside of the `#ifdef`/`#endif` pair are whitespace, comments, and the null directive `#` (for certain compilers
https://gcc.gnu.org/onlinedocs/cppinternals/Guard-Macros.html).  However, the previously mentioned `EA_PRAGMA_ONCE_SUPPORTED` check disables this optimization.

This commit moves the `#pragma once` code after the include directive where `EA_PRAGMA_ONCE_SUPPORTED` would be defined.  It also tidies up the traditional include guard so that it satisfies the stricter rules mentioned above.

This was issues was found with IncludeGuardian 0.0.7.